### PR TITLE
require 'forwardable'

### DIFF
--- a/lib/fozzie/configuration.rb
+++ b/lib/fozzie/configuration.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'sys/uname'
 require 'timeout'
+require 'forwardable'
 
 module Fozzie
 


### PR DESCRIPTION
Fixes: uninitialized constant Fozzie::Configuration::Forwardable (NameError)