### PR TITLE
Release 1.1.0; Add Datadog support and tags

### DIFF
--- a/lib/fozzie/adapter.rb
+++ b/lib/fozzie/adapter.rb
@@ -1,1 +1,1 @@
-%w{statsd}.each {|r| require "fozzie/adapter/#{r}" }
+%w{statsd datadog}.each {|r| require "fozzie/adapter/#{r}" }

--- a/lib/fozzie/adapter/datadog.rb
+++ b/lib/fozzie/adapter/datadog.rb
@@ -1,0 +1,26 @@
+require 'fozzie/adapter/statsd'
+
+module Fozzie
+  module Adapter
+    class Datadog < Statsd
+
+      # stats is a collection of hashes in the following format:
+      # { :bucket => stat, :value => value, :type => type, :sample_rate => sample_rate, tags => ["serviceid:fozzie","country:au"] }
+      def register(*stats)
+        metrics = stats.flatten.map do |stat|
+          next if sampled?(stat[:sample_rate])
+
+          bucket = format_bucket(stat[:bucket])
+          value  = format_value(stat[:value], stat[:type], stat[:sample_rate])
+          tags   = (stat[:tags] || []).map {|tag| tag.gsub(/[,\|]/, RESERVED_CHARS_REPLACEMENT)}
+
+          result = "#{bucket}:#{value}" 
+          result << "|##{tags.join(',')}" if tags.any? 
+          result
+        end.compact.join(BULK_DELIMETER)
+
+        send_to_socket(metrics)
+      end
+    end
+  end
+end

--- a/lib/fozzie/adapter/statsd.rb
+++ b/lib/fozzie/adapter/statsd.rb
@@ -3,7 +3,6 @@ require 'resolv'
 
 module Fozzie
   module Adapter
-
     class Statsd
 
       RESERVED_CHARS_REGEX       = /[\:\|\@\s]/
@@ -17,10 +16,10 @@ module Fozzie
       #
       # Creates the Statsd key from the given values, and sends to socket (depending on sample rate)
       def register(*stats)
-        metrics = stats.flatten.collect do |stat|
+        metrics = stats.flatten.map do |stat|
           next if sampled?(stat[:sample_rate])
 
-          bucket = format_bucket(stat[:bin])
+          bucket = format_bucket(stat[:bucket])
           value  = format_value(stat[:value], stat[:type], stat[:sample_rate])
 
           [bucket, value].join(':')

--- a/lib/fozzie/bulk_dsl.rb
+++ b/lib/fozzie/bulk_dsl.rb
@@ -11,9 +11,8 @@ module Fozzie
     private
 
     # Cache the requested metrics for bulk sending
-    #
-    def send(stat, value, type, sample_rate = 1)
-     val = { :bin => stat, :value => value, :type => type, :sample_rate => sample_rate }
+    def send(stat, value, type, sample_rate = 1, extra = {})
+     val = extra.merge({ :bucket => stat, :value => value, :type => type, :sample_rate => sample_rate })
 
      @metrics.push(val)
     end

--- a/lib/fozzie/configuration.rb
+++ b/lib/fozzie/configuration.rb
@@ -105,7 +105,5 @@ module Fozzie
     def full_config_path(path)
       File.expand_path('config/fozzie.yml', path)
     end
-
   end
-
 end

--- a/lib/fozzie/dsl.rb
+++ b/lib/fozzie/dsl.rb
@@ -9,11 +9,9 @@ module Fozzie
 
     # Send the statistic to the chosen provider
     #
-    def send(stat, value, type, sample_rate = 1)
-     val = { :bin => stat, :value => value, :type => type, :sample_rate => sample_rate }
-
-     adapter.register(val)
+    def send(stat, value, type, sample_rate = 1, extra = {})
+      val = extra.merge(:bucket => stat, :value => value, :type => type, :sample_rate => sample_rate)
+      adapter.register(val)
     end
-
   end
 end

--- a/lib/fozzie/interface.rb
+++ b/lib/fozzie/interface.rb
@@ -1,4 +1,5 @@
 require 'fozzie/adapter/statsd'
+require 'fozzie/adapter/datadog'
 
 module Fozzie
   module Interface
@@ -6,118 +7,118 @@ module Fozzie
     # Increments the given stat by one, with an optional sample rate
     #
     # `Stats.increment 'wat'`
-    def increment(stat, sample_rate=1)
-      count(stat, 1, sample_rate)
+    def increment(stat, sample_rate=1, extra = {})
+      count(stat, 1, sample_rate, extra)
     end
 
     # Decrements the given stat by one, with an optional sample rate
     #
     # `Stats.decrement 'wat'`
-    def decrement(stat, sample_rate=1)
-      count(stat, -1, sample_rate)
+    def decrement(stat, sample_rate=1, extra = {})
+      count(stat, -1, sample_rate, extra)
     end
 
     # Registers a count for the given stat, with an optional sample rate
     #
     # `Stats.count 'wat', 500`
-    def count(stat, count, sample_rate=1)
-      send(stat, count, :count, sample_rate)
+    def count(stat, count, sample_rate=1, extra = {})
+      send(stat, count, :count, sample_rate, extra)
     end
 
     # Registers a timing (in ms) for the given stat, with an optional sample rate
     #
     # `Stats.timing 'wat', 500`
-    def timing(stat, ms, sample_rate=1)
-      send(stat, ms, :timing, sample_rate)
+    def timing(stat, ms, sample_rate=1, extra = {})
+      send(stat, ms, :timing, sample_rate, extra)
     end
 
     # Registers the time taken to complete a given block (in ms), with an optional sample rate
     #
     # `Stats.time 'wat' { # Do something... }`
-    def time(stat, sample_rate=1)
+    def time(stat, sample_rate=1, extra = {})
       start  = Time.now
       result = yield
-      timing(stat, ((Time.now - start) * 1000).round, sample_rate)
+      timing(stat, ((Time.now - start) * 1000).round, sample_rate, extra)
       result
     end
 
     # Registers the time taken to complete a given block (in ms), with an optional sample rate
     #
     # `Stats.time_to_do 'wat' { # Do something, again... }`
-    def time_to_do(stat, sample_rate=1, &block)
-      time(stat, sample_rate, &block)
+    def time_to_do(stat, sample_rate=1, extra = {}, &block)
+      time(stat, sample_rate, extra, &block)
     end
 
     # Registers the time taken to complete a given block (in ms), with an optional sample rate
     #
     # `Stats.time_for 'wat' { # Do something, grrr... }`
-    def time_for(stat, sample_rate=1, &block)
-      time(stat, sample_rate, &block)
+    def time_for(stat, sample_rate=1, extra = {}, &block)
+      time(stat, sample_rate, extra, &block)
     end
 
     # Registers a commit
     #
     # `Stats.commit`
-    def commit
-      event :commit
+    def commit(extra = {})
+      event(:commit, nil, extra)
     end
 
     # Registers a commit
     #
     # `Stats.commit`
-    def committed
-      commit
+    def committed(extra = {})
+      commit(extra)
     end
 
     # Registers that the app has been built
     #
     # `Stats.built`
-    def built
-      event :build
+    def built(extra = {})
+      event(:build, nil, extra)
     end
 
     # Registers a build for the app
     #
     # `Stats.build`
-    def build
-      built
+    def build(extra = {})
+      built(extra)
     end
 
     # Registers a deployed status for the given app
     #
     # `Stats.deployed 'watapp'`
-    def deployed(app = nil)
-      event :deploy, app
+    def deployed(app = nil, extra = {})
+      event(:deploy, app, extra)
     end
 
     # Registers a deployment for the given app
     #
     # `Stats.deploy 'watapp'`
-    def deploy(app = nil)
-      deployed(app)
+    def deploy(app = nil, extra = {})
+      deployed(app, extra)
     end
 
     # Register an event of any type
     #
     # `Stats.event 'wat', 'app'`
-    def event(type, app = nil)
-      gauge ["event", type.to_s, app], Time.now.usec
+    def event(type, app = nil, extra = {})
+      gauge(["event", type.to_s, app], Time.now.usec, 1, extra)
     end
 
     # Registers an increment on the result of the given boolean
     #
     # `Stats.increment_on 'wat', wat.random?`
-    def increment_on(stat, perf, sample_rate=1)
+    def increment_on(stat, perf, sample_rate=1, extra = {})
       key = [stat, (perf ? "success" : "fail")]
-      increment(key, sample_rate)
+      increment(key, sample_rate, extra)
       perf
     end
 
     # Register an arbitrary value
     #
     # `Stats.gauge 'wat', 'app'`
-    def gauge(stat, value, sample_rate = 1)
-      send(stat, value, :gauge, sample_rate)
+    def gauge(stat, value, sample_rate = 1, extra = {})
+      send(stat, value, :gauge, sample_rate, extra)
     end
 
     # Register multiple statistics in a single call
@@ -135,6 +136,5 @@ module Fozzie
     def adapter
       Fozzie.c.adapter
     end
-
   end
 end

--- a/lib/fozzie/version.rb
+++ b/lib/fozzie/version.rb
@@ -1,3 +1,3 @@
 module Fozzie
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end

--- a/spec/lib/fozzie/adapter/datadog_spec.rb
+++ b/spec/lib/fozzie/adapter/datadog_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'fozzie/adapter/datadog'
+
+module Fozzie::Adapter
+  describe Datadog do
+    it_behaves_like "fozzie adapter"
+
+    # Switch to Statsd adapter for the duration of this test
+    before(:all) do
+      Fozzie.c.adapter = :Datadog
+    end
+
+    after(:all) do
+      Fozzie.c.adapter = :TestAdapter
+    end
+
+    describe "#register" do
+      it "appends tags to the metrics" do
+        subject.should_receive(:send_to_socket).with(%r{\|#country:usa,testing$})
+
+        subject.register(:bucket => "foo", :value => 1, :type => :gauge, :sample_rate => 1, tags: ['country:usa','testing'])
+      end
+
+      it "does not append tags when none are specified" do
+        subject.should_receive(:send_to_socket).with(%r{foo:1\|g$})
+
+        subject.register(:bucket => "foo", :value => 1, :type => :gauge, :sample_rate => 1)
+      end
+    end
+  end
+end

--- a/spec/lib/fozzie/adapter/statsd_spec.rb
+++ b/spec/lib/fozzie/adapter/statsd_spec.rb
@@ -15,16 +15,16 @@ module Fozzie::Adapter
     end
     
     it "downcases any stat value" do
-      subject.should_receive(:send_to_socket).with {|bin| bin.match /\.foo/ }
+      subject.should_receive(:send_to_socket).with(/\.foo/)
 
-      subject.register(:bin => "FOO", :value => 1, :type => :gauge, :sample_rate => 1)
+      subject.register(:bucket => "FOO", :value => 1, :type => :gauge, :sample_rate => 1)
     end
 
     describe "#format_bucket" do
       it "accepts arrays" do
-        subject.format_bucket([:foo, '2']).should match /foo.2$/
-        subject.format_bucket([:foo, '2']).should match /foo.2$/
-        subject.format_bucket(%w{foo bar}).should match /foo.bar$/
+        subject.format_bucket([:foo, '2']).should match(/foo.2$/)
+        subject.format_bucket([:foo, '2']).should match(/foo.2$/)
+        subject.format_bucket(%w{foo bar}).should match(/foo.bar$/)
       end
 
       it "converts any values to strings for stat value, ignoring nil" do
@@ -32,9 +32,9 @@ module Fozzie::Adapter
       end
 
       it "replaces invalid chracters" do
-        subject.format_bucket([:foo, ':']).should match /foo.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/
-        subject.format_bucket([:foo, '@']).should match /foo.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/
-        subject.format_bucket('foo.bar.|').should match /foo.bar.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/
+        subject.format_bucket([:foo, ':']).should match(/foo.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/)
+        subject.format_bucket([:foo, '@']).should match(/foo.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/)
+        subject.format_bucket('foo.bar.|').should match(/foo.bar.#{subject.class::RESERVED_CHARS_REPLACEMENT}$/)
       end
     end
 
@@ -51,15 +51,15 @@ module Fozzie::Adapter
     it "ensures block is called on socket error" do
       subject.socket.stub(:send) { raise SocketError }
 
-      proc { subject.register(:bin => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1) { sleep 0.01 } }.should_not raise_error
-      proc { subject.register(:bin => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1) { sleep 0.01 } }.should_not raise_error
+      proc { subject.register(:bucket => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1) { sleep 0.01 } }.should_not raise_error
+      proc { subject.register(:bucket => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1) { sleep 0.01 } }.should_not raise_error
     end
 
     it "raises Timeout on slow lookup" do
       Fozzie.c.timeout = 0.01
       subject.socket.stub(:send).with(any_args) { sleep 0.4 }
 
-      subject.register(:bin => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1).should eq false
+      subject.register(:bucket => 'data.bin', :value => 1, :type => :gauge, :sample_rate => 1).should eq false
     end
 
     describe "multiple stats in a single call" do
@@ -68,9 +68,9 @@ module Fozzie::Adapter
         Fozzie.c.disable_prefix
 
         stats = [
-          { :bin => 'foo', :value => 1, :type => :count, :sample_rate => 1 },
-          { :bin => 'bar', :value => 1, :type => :gauge, :sample_rate => 1 },
-          { :bin => %w{foo bar}, :value => 100, :type => :timing, :sample_rate => 1 }
+          { :bucket => 'foo', :value => 1, :type => :count, :sample_rate => 1 },
+          { :bucket => 'bar', :value => 1, :type => :gauge, :sample_rate => 1 },
+          { :bucket => %w{foo bar}, :value => 100, :type => :timing, :sample_rate => 1 }
         ]
 
         subject.should_receive(:send_to_socket).with "foo:1|c\nbar:1|g\nfoo.bar:100|ms"

--- a/spec/lib/fozzie/configuration_spec.rb
+++ b/spec/lib/fozzie/configuration_spec.rb
@@ -86,17 +86,17 @@ describe Fozzie::Configuration do
   describe "#sniff?" do
     it "defaults to false for testing" do
       subject.stub(:env => "test")
-      subject.sniff?.should be_false
+      subject.sniff?.should be false
     end
 
     it "defaults true when in development" do
       subject.stub(:env => "development")
-      subject.sniff?.should be_true
+      subject.sniff?.should be true
     end
 
     it "defaults true when in production" do
       subject.stub(:env => "production")
-      subject.sniff?.should be_true
+      subject.sniff?.should be true
     end
   end
 
@@ -105,12 +105,12 @@ describe Fozzie::Configuration do
 
     it "scopes to return false" do
       subject.stub(:env => "development")
-      subject.sniff?.should be_false
+      subject.sniff?.should be false
     end
 
     it "scopes to return true" do
       subject.stub(:env => "test")
-      subject.sniff?.should be_true
+      subject.sniff?.should be true
     end
 
   end

--- a/spec/lib/fozzie/rack/sinatra_spec.rb
+++ b/spec/lib/fozzie/rack/sinatra_spec.rb
@@ -15,14 +15,14 @@ describe "Sinatra Server with Middleware" do
   end
 
   it "sends stats request on root" do
-    S.should_receive(:timing).with('index.render', anything, anything)
+    S.should_receive(:timing).with('index.render', anything, anything, anything)
     get '/'
     last_response.should be_ok
     last_response.body.should == 'echo'
   end
 
   it "sends stats request on nested path" do
-    S.should_receive(:timing).with('somewhere.nice.render', anything, anything)
+    S.should_receive(:timing).with('somewhere.nice.render', anything, anything, anything)
 
     get '/somewhere/nice'
     last_response.should be_ok

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,6 @@ root   = File.expand_path('../', File.dirname(__FILE__))
 lib    = File.expand_path('lib', root)
 $:.unshift(root, lib)
 
-# Shared Examples
-Dir[File.expand_path('spec/shared_examples/*.rb')].each {|r| require r }
-
 require 'fozzie'
 
 module Fozzie
@@ -26,4 +23,10 @@ end
 
 RSpec.configure do |config|
   config.order = :random
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.mock_with(:rspec) { |c| c.syntax = :should }
+  config.raise_errors_for_deprecations!
 end
+
+# Shared Examples
+Dir[File.expand_path('spec/shared_examples/*.rb')].each {|r| require r }


### PR DESCRIPTION
Changes:
* DSL methods accept additional `extra` argument
* Datadog adapter with tags support has been added

Tags are not supported by Statsd and will be ignored by the default
adapter. To use tags change adatpter to `Datadog`:

```
Fozzie.c.adapter = :Datadog
```

Tags are optional.

If tags are not used Datadog adapter is 100% compatible with Statsd
server.